### PR TITLE
Add puppetlabs/stdlib dependency to Modulefile.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -6,3 +6,5 @@ license 'Apache License, Version 2.0'
 summary 'Manages inittab'
 description 'Manages inittab'
 project_page 'https://github.com/ghoneycutt/puppet-module-inittab'
+
+dependency 'puppetlabs/stdlib', '3.2.x'


### PR DESCRIPTION
validate_re is used in this module. This function requires
puppetlabs/stdlib.
