### PR TITLE
Support rspec-puppet v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 env:
-- PUPPET_VERSION=2.7.22
-- PUPPET_VERSION=3.3.1
+- PUPPET_VERSION=2.7.23
+- PUPPET_VERSION=3.3.2
 notifications:
 email: false
 rvm:
@@ -9,7 +9,7 @@ rvm:
 - 1.8.7
 matrix:
   allow_failures:
-  - env: PUPPET_VERSION=2.7.22
+  - env: PUPPET_VERSION=2.7.23
 language: ruby
 before_script: "gem install --no-ri --no-rdoc bundler"
 script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
-source :rubygems
+source "https://rubygems.org"
 
 puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 2.7']
 gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 0.3.2'
+gem 'facter', '>= 1.7.0', "< 1.8.0"

--- a/Rakefile
+++ b/Rakefile
@@ -6,10 +6,13 @@ PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
 desc "Run puppet in noop mode and check for syntax errors."
 task :validate do
-   Dir['manifests/**/*.pp'].each do |path|
-     sh "puppet parser validate --noop #{path}"
-   end
-   Dir['spec/**/*.rb','lib/**/*.rb'].each do |spec_path|
-     sh "ruby -c #{spec_path}" unless spec_path =~ /spec\/fixtures/
-   end
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -19,7 +19,7 @@ describe 'inittab' do
 
     it 'should fail' do
       expect {
-        should include_class('inittab')
+        should contain_class('inittab')
       }.to raise_error(Puppet::Error,/default_runlevel <10> does not match regex/)
     end
   end
@@ -33,7 +33,7 @@ describe 'inittab' do
 
     it 'should fail' do
       expect {
-        should include_class('inittab')
+        should contain_class('inittab')
       }.to raise_error(Puppet::Error,/lsbmajdistrelease is <0> and inittab supports versions 5 and 6./)
     end
   end
@@ -45,7 +45,7 @@ describe 'inittab' do
       }
     end
 
-    it { should include_class('inittab::ubuntu') }
+    it { should contain_class('inittab::ubuntu') }
   end
 
   describe 'Debian family systems of unsupported version' do
@@ -58,7 +58,7 @@ describe 'inittab' do
 
     it 'should fail' do
       expect {
-        should include_class('inittab')
+        should contain_class('inittab')
       }.to raise_error(Puppet::Error,/lsbmajdistrelease is <23> and inittab supports version 6./)
     end
   end
@@ -68,7 +68,7 @@ describe 'inittab' do
 
     it 'should fail' do
       expect {
-        should include_class('inittab')
+        should contain_class('inittab')
       }.to raise_error(Puppet::Error,/osfamily is <UNSUPPORTED> and inittab module supports Debian, RedHat, Ubuntu, Suse, and Solaris./)
     end
   end
@@ -81,7 +81,7 @@ describe 'inittab' do
       }
     end
 
-    it { should include_class('inittab') }
+    it { should contain_class('inittab') }
 
     it { should_not contain_file('rc-sysinit.override')  }
 
@@ -105,7 +105,7 @@ describe 'inittab' do
       }
     end
 
-    it { should include_class('inittab') }
+    it { should contain_class('inittab') }
 
     it {
       should contain_file('inittab').with({
@@ -129,7 +129,7 @@ describe 'inittab' do
       }
     end
 
-    it { should include_class('inittab') }
+    it { should contain_class('inittab') }
 
     it {
       should contain_file('inittab').with({
@@ -153,7 +153,7 @@ describe 'inittab' do
       }
     end
 
-    it { should include_class('inittab') }
+    it { should contain_class('inittab') }
 
     it {
       should contain_file('inittab').with({
@@ -175,7 +175,7 @@ describe 'inittab' do
       }
     end
 
-    it { should include_class('inittab') }
+    it { should contain_class('inittab') }
 
     it {
       should contain_file('inittab').with({
@@ -197,7 +197,7 @@ describe 'inittab' do
       }
     end
 
-    it { should include_class('inittab') }
+    it { should contain_class('inittab') }
 
     it {
       should contain_file('inittab').with({

--- a/spec/classes/ubuntu_spec.rb
+++ b/spec/classes/ubuntu_spec.rb
@@ -8,7 +8,7 @@ describe 'inittab::ubuntu' do
       }
     end
 
-    it { should include_class('inittab') }
+    it { should contain_class('inittab') }
 
     it {
       should contain_file('inittab').with({


### PR DESCRIPTION
include_class has been replaced with contain_class.
http://bombasticmonkey.com/2013/12/05/rspec-puppet-1.0.0/
