### PR TITLE
resolves #60 use operatingsystemrelease and regex for SuSE until facter fully supports all OSs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,17 +65,17 @@ class inittab (
       }
     }
     'Suse':{
-      case $::operatingsystemmajrelease {
-        '10': {
+      case $::operatingsystemrelease {
+        /^10/: {
           $default_default_runlevel = 3
           $template                 = 'inittab/suse10.erb'
         }
-        '11': {
+        /^11/: {
           $default_default_runlevel = 3
           $template                 = 'inittab/suse11.erb'
         }
         default: {
-          fail("operatingsystemmajrelease is <${::operatingsystemmajrelease}> and inittab supports Suse versions 10 and 11.")
+          fail("operatingsystemrelease is <${::operatingsystemrelease}> and inittab supports Suse versions 10 and 11.")
         }
       }
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -106,12 +106,12 @@ describe 'inittab' do
     'suse10' =>
       { :osfamily                   => 'Suse',
         :release                    => '10',
-        :operatingsystemmajrelease  => '10',
+        :operatingsystemrelease     => '10.4',
       },
     'suse11' =>
       { :osfamily                   => 'Suse',
         :release                    => '11',
-        :operatingsystemmajrelease  => '11',
+        :operatingsystemrelease     => '11.3',
       },
   }
 
@@ -121,6 +121,7 @@ describe 'inittab' do
       context "#{v[:osfamily]} #{v[:release]}" do
         let :facts do
           { :osfamily                   => v[:osfamily],
+            :operatingsystemrelease     => v[:operatingsystemrelease],
             :operatingsystemmajrelease  => v[:operatingsystemmajrelease],
             :kernelrelease              => v[:kernelrelease],
           }


### PR DESCRIPTION
I switched out operatingsystemmajrelease for operatingsystemrelease and used regex to only grab the major version. I think this will solve our problems with lsb and get SuSE working fine until an upstream patch comes through for facter which I'm working on. Solaris uses the kernelrelease fact and shouldn't be affected.

If we don't like having this exception, one option is to use operatingsystemrelease and regex for all OSs until the operatingsystemmajrelease fact is more widely supported.
