### PR TITLE
fixing RH OS detection

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,17 +8,17 @@ class inittab (
 
   case $::osfamily {
     'RedHat': {
-      case $::operatingsystemmajrelease {
-        '5': {
+      case $::operatingsystemrelease {
+        /^5/: {
           $default_default_runlevel = 3
           $template                 = 'inittab/el5.erb'
         }
-        '6': {
+        /^6/: {
           $default_default_runlevel = 3
           $template                 = 'inittab/el6.erb'
         }
         default: {
-          fail("operatingsystemmajrelease is <${::operatingsystemmajrelease}> and inittab supports RedHat versions 5 and 6.")
+          fail("operatingsystemrelease is <${::operatingsystemrelease}> and inittab supports RedHat versions 5 and 6.")
         }
       }
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -14,8 +14,8 @@ describe 'inittab' do
   describe 'with default_runlevel set to invalid value' do
     let(:params) { { :default_runlevel => '10' } }
     let :facts do
-      { :osfamily                   => 'RedHat',
-        :operatingsystemmajrelease  => '6',
+      { :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6.5',
       }
     end
 
@@ -29,15 +29,15 @@ describe 'inittab' do
   describe 'with unsupported' do
     context 'version of osfamily RedHat' do
       let :facts do
-        { :osfamily                   => 'RedHat',
-          :operatingsystemmajrelease  => '0',
+        { :osfamily               => 'RedHat',
+          :operatingsystemrelease => '0',
         }
       end
 
       it 'should fail' do
         expect {
           should contain_class('inittab')
-        }.to raise_error(Puppet::Error,/^operatingsystemmajrelease is <0> and inittab supports RedHat versions 5 and 6./)
+        }.to raise_error(Puppet::Error,/^operatingsystemrelease is <0> and inittab supports RedHat versions 5 and 6./)
       end
     end
 
@@ -93,26 +93,27 @@ describe 'inittab' do
 end
 
   platforms = {
+
     'debian6' =>
       { :osfamily                   => 'Debian',
         :release                    => '6',
         :operatingsystemmajrelease  => '6',
       },
     'el5' =>
-      { :osfamily                   => 'RedHat',
-        :release                    => '5',
-        :operatingsystemmajrelease  => '5',
+      { :osfamily               => 'RedHat',
+        :release                => '5',
+        :operatingsystemrelease => '5.9',
       },
     'el5xenu' =>
-      { :osfamily                   => 'RedHat',
-        :release                    => '5',
-        :operatingsystemmajrelease  => '5',
-        :virtual                    => 'xenu',
+      { :osfamily               => 'RedHat',
+        :release                => '5',
+        :operatingsystemrelease => '5.9',
+        :virtual                => 'xenu',
       },
     'el6' =>
-      { :osfamily                   => 'RedHat',
-        :release                    => '6',
-        :operatingsystemmajrelease  => '6',
+      { :osfamily               => 'RedHat',
+        :release                => '6',
+        :operatingsystemrelease => '6.5',
       },
     'solaris10' =>
       { :osfamily      => 'Solaris',


### PR DESCRIPTION
fixes issue https://github.com/ghoneycutt/puppet-module-inittab/issues/68: Using operatingsystemmajrelease breaks on RedHat 6.5.
Also true when LSB packages are installed:

<pre>
[root@test ~]# rpm -qa | grep lsb
redhat-lsb-printing-4.0-7.el6.x86_64
redhat-lsb-4.0-7.el6.x86_64
redhat-lsb-core-4.0-7.el6.x86_64
redhat-lsb-compat-4.0-7.el6.x86_64
redhat-lsb-graphics-4.0-7.el6.x86_64

[root@test ~]# facter operatingsystemmajrelease
[root@test ~]# facter operatingsystemrelease
6.5
</pre>
