### PR TITLE
Rhel8

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -208,10 +208,10 @@ class inittab (
 
   if $systemd == true {
     case $default_runlevel_real {
-      3: {
+      '3': {
         $target = '/lib/systemd/system/multi-user.target'
       }
-      5: {
+      '5': {
         $target = '/lib/systemd/system/graphical.target'
       }
       default: {
@@ -231,7 +231,7 @@ class inittab (
 
     if $ctrlaltdelburstaction {
       validate_re($ctrlaltdelburstaction,'^(reboot-force)|(poweroff-force)|(reboot-immediate)|(poweroff-immediate)|(none)$',
-      "inittab::ctrlaltdelburstaction is ${ctrlaltdelburstaction} and if defined must be one of 'reboot-force', 'poweroff-force', 'reboot-immediate', 'poweroff-immediate', 'none'.")
+      "inittab::ctrlaltdelburstaction is ${ctrlaltdelburstaction} and must be one of 'reboot-force', 'poweroff-force', 'reboot-immediate', 'poweroff-immediate', 'none'.")
 
       file_line { 'CtrlAltDelBurstAction':
         ensure => present,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,7 +95,7 @@ class inittab (
           $systemd                     = true
         }
         default: {
-          fail("OS Release is <${facts['os']['release']['major']}> and inittab supports RedHat Enterprise versions 5 through 9.")
+          fail("OS Release is <${facts['os']['release']['major']}> and inittab supports RedHat Enterprise versions 5 through 8.")
         }
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -9,10 +9,10 @@
   "project_page": "https://github.com/ghoneycutt/puppet-module-inittab",
   "issues_url": "https://github.com/ghoneycutt/puppet-module-inittab/issues",
   "requirements": [
-    {"name":"puppet","version_requirement":">= 3.0.0 < 7.0.0"}
+    {"name":"puppet","version_requirement":">= 3.0.0 < 8.0.0"}
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 9.0.0"}
   ],
   "operatingsystem_support": [
     {
@@ -26,7 +26,8 @@
       "operatingsystemrelease": [
         "5",
         "6",
-        "7"
+        "7",
+		"8"
       ]
     },
     {
@@ -34,7 +35,8 @@
       "operatingsystemrelease": [
         "5",
         "6",
-        "7"
+        "7",
+		"8"
       ]
     },
     {
@@ -42,7 +44,8 @@
       "operatingsystemrelease": [
         "5",
         "6",
-        "7"
+        "7",
+		"8"
       ]
     },
     {
@@ -50,7 +53,8 @@
       "operatingsystemrelease": [
         "5",
         "6",
-        "7"
+        "7",
+		"8"
       ]
     },
     {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -422,6 +422,14 @@ end
         :support_ctrlaltdel_override => 'false',
         :systemd                     => true,
       },
+    'el8' =>
+      { :osfamily                    => 'RedHat',
+        :release                     => '8',
+        :operatingsystem             => 'RedHat',
+        :operatingsystemrelease      => '8.0',
+        :support_ctrlaltdel_override => 'false',
+        :systemd                     => true,
+      },
     'solaris10' =>
       { :osfamily                    => 'Solaris',
         :release                     => '10',

--- a/templates/el8.erb
+++ b/templates/el8.erb
@@ -1,0 +1,18 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+# inittab is no longer used when using systemd.
+#
+# ADDING CONFIGURATION HERE WILL HAVE NO EFFECT ON YOUR SYSTEM.
+#
+# Ctrl-Alt-Delete is handled by /etc/systemd/system/ctrl-alt-del.target
+#
+# systemd uses 'targets' instead of runlevels. By default, there are two main targets:
+#
+# multi-user.target: analogous to runlevel 3
+# graphical.target: analogous to runlevel 5
+#
+# To set a default target, run:
+#
+# ln -sf /lib/systemd/system/<target name>.target /etc/systemd/system/default.target
+#


### PR DESCRIPTION
A little bit more than just RHEL8.  Code used various legacy $::operatingsystemrelease and $::operatingsystemmajrelease facts, which meant it jumped back and forth from String comparison to RegExp comparison (and some Integer comparison).  Changed everything to use modern, structured facts and standardized on $facts['os']['release']['major'] so everything can be String.

Probably needs to change minimum supported version of Puppet to '>= 4.0.0', as I think that is when structured facts were introduced.  